### PR TITLE
修改截图框超标时按照传入的比例重新赋值

### DIFF
--- a/src/vue-cropper.vue
+++ b/src/vue-cropper.vue
@@ -1653,18 +1653,20 @@ export default {
     },
     // 手动改变截图框大小函数
     changeCrop(w, h) {
+      let whRate = w / h;
+      if (Number.isNaN(whRate)) whRate = this.fixedNumber[0] / this.fixedNumber[1];
       if (this.centerBox) {
         // 修复初始化时候在centerBox=true情况下
         let axis = this.getImgAxis();
         if (w > axis.x2 - axis.x1) {
           // 宽度超标
           w = axis.x2 - axis.x1;
-          h = (w / this.fixedNumber[0]) * this.fixedNumber[1];
+          h = w / whRate;
         }
         if (h > axis.y2 - axis.y1) {
           // 高度超标
           h = axis.y2 - axis.y1;
-          w = (h / this.fixedNumber[1]) * this.fixedNumber[0];
+          w = h * whRate;
         }
       }
       // 判断是否大于容器


### PR DESCRIPTION
现在在手动修改截图框超标的时候按照 `fixedNumber` 重新赋值。
这种情况有个问题是：`fixedNumber` 有可能使用默认值 1 : 1，导致出现不可预料的情况。
比如：某个时刻我希望截图框是 800px * 200px(整个截图区域也这么大)，所以我使用 `changeCrop(800, 200)`。如果这个时候的图片大小是 400px * 400px，结果截图框会变成 400px * 400px ，超过截图区域。如果截图框按照比例重新赋值为 400px * 100px的话可能会比较好。所以希望按照比例重新赋值。