### PR TITLE
修复在初始化的情况下  图片宽高超出时的计算  当不固定宽高时 无需计算相对应的宽高

### DIFF
--- a/src/vue-cropper.vue
+++ b/src/vue-cropper.vue
@@ -1828,12 +1828,16 @@ export default {
         if (w > axis.x2 - axis.x1) {
           // 宽度超标
           w = axis.x2 - axis.x1;
-          h = (w / this.fixedNumber[0]) * this.fixedNumber[1];
+	  if (this.fixed) {
+	    h = (w / this.fixedNumber[0]) * this.fixedNumber[1];
+	  }
         }
         if (h > axis.y2 - axis.y1) {
           // 高度超标
           h = axis.y2 - axis.y1;
-          w = (h / this.fixedNumber[1]) * this.fixedNumber[0];
+	  if (this.fixed) {
+	    w = (h / this.fixedNumber[1]) * this.fixedNumber[0];
+	  }
         }
       }
       // 判断是否大于容器


### PR DESCRIPTION
修复在初始化的情况下  图片宽高超出时的计算  当不固定宽高时 无需计算相对应的宽高