### PR TITLE
fix: 修复截选框在最小时最上方的原点未对齐

### DIFF
--- a/src/vue-cropper.vue
+++ b/src/vue-cropper.vue
@@ -2171,7 +2171,7 @@ export default {
 }
 
 .point2 {
-  top: -5px;
+  top: -4px;
   left: 50%;
   margin-left: -3px;
   cursor: n-resize;


### PR DESCRIPTION
截选图片内容时，缩到最小，上方的三个点没有对齐